### PR TITLE
starters: Ensure that VSCode emmet uses JSX syntax

### DIFF
--- a/starters/apps/base/.vscode/settings.json
+++ b/starters/apps/base/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "material-icon-theme.activeIconPack": "qwik",
   "emmet.includeLanguages": {
-    "typescriptreact": "html"
+    "typescriptreact": "xhtml"
   }
 }


### PR DESCRIPTION
# Overview

Fix emmet behavior for base

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description


```tsx
// Before
br => <br>
// After
br => <br/>
```

Also applies to `input`, `img`, etc.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
